### PR TITLE
Bug fix/profile fixes

### DIFF
--- a/backend/src/User/user.controller.ts
+++ b/backend/src/User/user.controller.ts
@@ -489,20 +489,22 @@ export const assignVolunteerType = async (req: Request, res: Response) => {
                 message: "User assigned to volunteer type",
                 success: true,
             });
-            const admins = await getAllAdmins();
-            const adminEmails: Array<string> = [""];
-            if (admins) {
-                for (let i = 0; i < admins.length; i++) {
-                    adminEmails[i] = admins[i].email;
+            if (!req.session.user?.isAdmin) {
+                const admins = await getAllAdmins();
+                const adminEmails: Array<string> = [""];
+                if (admins) {
+                    for (let i = 0; i < admins.length; i++) {
+                        adminEmails[i] = admins[i].email;
+                    }
                 }
+                void sendVolunteerRequestEmail(
+                    adminEmails,
+                    sessionUserId,
+                    userObj.firstName,
+                    userObj.lastName,
+                    targetVolType.name
+                );
             }
-            void sendVolunteerRequestEmail(
-                adminEmails,
-                sessionUserId,
-                userObj.firstName,
-                userObj.lastName,
-                targetVolType.name
-            );
             return;
         } else {
             res.status(404).json({

--- a/frontend/src/profile/profile.tsx
+++ b/frontend/src/profile/profile.tsx
@@ -136,7 +136,7 @@ export const ProfilePage = () => {
                                 )}
                             </div>
                         </div>
-                        <div className="volunteer-type-table">
+                        <div className="volunteer-type-table" hidden={!isAdmin && !editingSelf}>
                             <Table striped bordered hover>
                                 <thead>
                                     <tr>

--- a/frontend/src/profile/qualifications/qualificationManagement.tsx
+++ b/frontend/src/profile/qualifications/qualificationManagement.tsx
@@ -114,7 +114,7 @@ export const QualificationsSection = ({ userId, isAdmin, editingSelf }: Qualific
     };
 
     return (
-        <div className="qualification-table">
+        <div className="qualification-table" hidden={!isAdmin && !editingSelf}>
             <Table striped bordered hover>
                 <thead>
                     <tr>


### PR DESCRIPTION
Fixed being able to view/delete another user's volunteer types and qualifications as a non-admin.
Volunteer approval request email is no longer sent when an admin is the one adding the volunteer type, whether to a normal profile or an admin profile.