### PR TITLE
Removed notes field from shift controller

### DIFF
--- a/backend/src/Shift/shift.controller.ts
+++ b/backend/src/Shift/shift.controller.ts
@@ -796,7 +796,6 @@ export const exportAdminShifts = async (req: Request, res: Response) => {
                     `${shift.hours}`,
                     `${shift.category}`,
                     `${shift.description}`,
-                    `${shift.notes}`,
                     targetUser?._id.toString(),
                     targetUser?.firstName,
                     targetUser?.lastName,


### PR DESCRIPTION
##What?
Most of "Notes" was removed from existing files from the previous merge. However, one of the "Notes" was missed and did not get removed which prevented the backend from running.

##Why?
To get the backend running again.

##How?
Inspected the error message from the compiler which pointed at the file that still had "Notes". "Notes" was then removed from that file.