### PR TITLE
Removed the seconds on the shift info page

### DIFF
--- a/frontend/src/components/filterResultsModal/filterResultsModal.tsx
+++ b/frontend/src/components/filterResultsModal/filterResultsModal.tsx
@@ -95,7 +95,7 @@ export const FilterResultsModal = (props: FilterResultsModalProps): JSX.Element 
                                     aria-label="Shift Length"
                                 >
                                     <option value="All">All</option>
-                                    <option value="Short">Short (1-2 Hours)</option>
+                                    <option value="Short">Short (0-2 Hours)</option>
                                     <option value="Medium">Medium (3-4 Hours)</option>
                                     <option value="Long">Long (5+ Hours)</option>
                                 </Form.Select>

--- a/frontend/src/components/shiftCard.tsx
+++ b/frontend/src/components/shiftCard.tsx
@@ -49,7 +49,13 @@ export default function ShiftCard({ shiftData, isAdmin, handleSelected }: ShiftC
     const [showDupeModal, setShowDupeModal] = useState(false);
     const [shiftdata, setshiftData] = useState("");
 
-    const dateString = new Date(startAt).toLocaleString();
+    const dateString = new Date(startAt).toLocaleString([], {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
 
     const handleCloseModal = () => {
         setShowEditModal(false);

--- a/frontend/src/shiftInformation/shiftInformation.tsx
+++ b/frontend/src/shiftInformation/shiftInformation.tsx
@@ -290,7 +290,11 @@ const ShiftInformation = () => {
 
                                         <div className="info-box-right-container">
                                             <h3 className="info-body">
-                                                {startDate.toLocaleDateString()} {startDate.toLocaleTimeString()}
+                                                {startDate.toLocaleDateString()}{" "}
+                                                {startDate.toLocaleTimeString([], {
+                                                    hour: "2-digit",
+                                                    minute: "2-digit",
+                                                })}
                                             </h3>
                                         </div>
                                     </div>
@@ -303,7 +307,8 @@ const ShiftInformation = () => {
 
                                         <div className="info-box-right-container">
                                             <h3 className="info-body">
-                                                {endDate.toLocaleDateString()} {endDate.toLocaleTimeString()}
+                                                {endDate.toLocaleDateString()}{" "}
+                                                {endDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                                             </h3>
                                         </div>
                                     </div>


### PR DESCRIPTION
The seconds for the start and end date were removed from the shift information body and the shift card.