### PR TITLE
Previous filters are stored into the session storage instead of local storage.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "git.ignoreLimitWarning": true,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[typescriptreact]": {

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -22,6 +22,7 @@ export class NavigationBar extends React.Component<Record<string, never>, NavBar
             .then(({ success, status }) => {
                 if (success && status == 200) {
                     window.location.href = "/login";
+                    sessionStorage.clear();
                 } else {
                     console.error(`Failed to logout`);
                 }

--- a/frontend/src/shiftInformation/shiftInformation.css
+++ b/frontend/src/shiftInformation/shiftInformation.css
@@ -197,7 +197,7 @@
     font-family: "Segoe UI" !important;
     font-style: normal;
     font-weight: 400;
-    font-size: 14px;
+    font-size: 17px;
     line-height: 17px;
 
     color: #686868 !important;
@@ -212,7 +212,7 @@
     font-family: "Segoe UI";
     font-style: normal;
     font-weight: 400;
-    font-size: 14px;
+    font-size: 17px;
     line-height: 17px;
 
     color: #000000;

--- a/frontend/src/shiftpage/shiftpage.tsx
+++ b/frontend/src/shiftpage/shiftpage.tsx
@@ -34,7 +34,7 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
     const { data: userVolTypesData, isLoading: loadingUserVolTypes } = useVoltypesForUser(userData?.data?._id);
 
     const getFilterInLocalStorage = (): Filters => {
-        const localFiltersString: string | null = localStorage.getItem("shiftResultFilters");
+        const localFiltersString: string | null = sessionStorage.getItem("shiftResultFilters");
         // CONSOLE
         console.log(localFiltersString);
         if (!localFiltersString) {
@@ -80,7 +80,7 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
 
     //Saves most recent filter into the local storage
     const updateFiltersInLocalStorage = (filters: Filters) => {
-        localStorage.setItem("shiftResultFilters", JSON.stringify(filters));
+        sessionStorage.setItem("shiftResultFilters", JSON.stringify(filters));
         console.log("Updated");
         console.log(filters);
         console.log(JSON.stringify(filters));

--- a/frontend/src/shiftpage/shiftpage.tsx
+++ b/frontend/src/shiftpage/shiftpage.tsx
@@ -33,25 +33,25 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
     const { isLoading: loadingAllVolTypes, data: allVolTypes } = useAllVolTypes();
     const { data: userVolTypesData, isLoading: loadingUserVolTypes } = useVoltypesForUser(userData?.data?._id);
 
-    const getFilterInLocalStorage = (): Filters => {
-        const localFiltersString: string | null = sessionStorage.getItem("shiftResultFilters");
+    const getFilterInSessionStorage = (): Filters => {
+        const sessionFiltersString: string | null = sessionStorage.getItem("shiftResultFilters");
         // CONSOLE
-        console.log(localFiltersString);
-        if (!localFiltersString) {
+        console.log(sessionFiltersString);
+        if (!sessionFiltersString) {
             console.log("Default");
             return getDefaultFilters(userVolTypesData?.data || []);
         }
-        const localFilters = JSON.parse(localFiltersString) as Filters;
+        const sessionFilters = JSON.parse(sessionFiltersString) as Filters;
         const something = {
-            from: new Date(localFilters.from),
-            to: new Date(localFilters.to),
-            volTypes: localFilters.volTypes,
-            category: localFilters.category,
-            hours: localFilters.hours,
-            hideUnavailable: localFilters.hideUnavailable,
+            from: new Date(sessionFilters.from),
+            to: new Date(sessionFilters.to),
+            volTypes: sessionFilters.volTypes,
+            category: sessionFilters.category,
+            hours: sessionFilters.hours,
+            hideUnavailable: sessionFilters.hideUnavailable,
         };
-        // CONSOLE localFilters
-        console.log(localFilters);
+        // CONSOLE sessionFilters
+        console.log(sessionFilters);
         return something;
     };
 
@@ -78,8 +78,8 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
 
     // setResultFilters(something);
 
-    //Saves most recent filter into the local storage
-    const updateFiltersInLocalStorage = (filters: Filters) => {
+    //Saves most recent filter into the session storage
+    const updateFiltersInSessionStorage = (filters: Filters) => {
         sessionStorage.setItem("shiftResultFilters", JSON.stringify(filters));
         console.log("Updated");
         console.log(filters);
@@ -106,7 +106,7 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
         console.log("useEffect");
         if (userVolTypesData) {
             // setResultFilters(getDefaultFilters(userVolTypesData?.data || []));
-            setResultFilters(getFilterInLocalStorage());
+            setResultFilters(getFilterInSessionStorage());
         }
     }, [userVolTypesData]);
 
@@ -260,7 +260,7 @@ const ShiftPage = ({ shiftType }: ShiftPageProps) => {
                             filters={resultFilters}
                             updateFilters={(filters) => {
                                 setResultFilters(filters);
-                                updateFiltersInLocalStorage(filters);
+                                updateFiltersInSessionStorage(filters);
                             }}
                             onClose={() => setFilterPanelVisible(false)}
                             allVolTypes={allVolTypes?.data || []}


### PR DESCRIPTION
Filter data was previously stored in local storage, so that users don't need to constantly change their filters when they come back to the shifts page.

However, the saved filter set by the previous user is still applied to the new user. 

To rectify this issue, filter data is now stored in the session storage. Meaning that all filter data will be cleared when the user logs out or closes their window. 

